### PR TITLE
Enhance README.md with detailed project information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
-# AOJ
+# Aizu Online Judge (AOJ) Solutions
+
+This repository contains solutions to problems from the Aizu Online Judge (AOJ). The solutions are primarily written in Python and C++.
+
+## Directory Structure
+
+The solutions are organized into directories based on the AOJ courses or problem sets. For example:
+
+- `ALDS1`: Solutions for the "Algorithm and Data Structures I" course.
+- `DPL`: Solutions for the "Dynamic Programming" course.
+- `GRL`: Solutions for the "Graph Algorithms" course.
+- `ITP1`: Solutions for the "Introduction to Programming I" course.
+- `NTL`: Solutions for the "Number Theory" course.
+
+Each directory contains individual files, usually named according to the problem ID on AOJ.
+
+## How to Use
+
+1.  Navigate to the directory corresponding to the course or problem set you are interested in.
+2.  Find the file corresponding to the specific problem ID.
+3.  The file contains the solution code for that problem.
+
+## License
+
+```
+MIT License
+
+Copyright (c) 2019 ToshikiShimizu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```


### PR DESCRIPTION
The README.md file has been updated to provide a comprehensive overview of the repository.

This includes:
- A clear title and introduction explaining that the repository hosts Aizu Online Judge (AOJ) solutions.
- An explanation of the directory structure, clarifying how solutions are organized by AOJ courses or problem sets.
- Instructions on how to navigate and use the solutions within the repository.
- The inclusion of the MIT License under which the project is shared.

This enhanced README will help you better understand the purpose and content of the repository.